### PR TITLE
feat: add excluded providers functionality to optimization process

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -47,6 +47,7 @@ class OptimizationInput:
     earnings: Optional[float] = None
     isa_allowance_used: Optional[float] = 0.0
     other_savings_income: Optional[float] = 0.0
+    excluded_providers: Optional[List[str]] = None
     # Other constraints can be added here
     # e.g., max_isa_investment: float = 20000
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -51,6 +51,14 @@ def optimize():
         else:
             other_savings_income = 0.0
 
+        excluded_providers = data.get('excluded_providers')
+        if excluded_providers is not None:
+            if not isinstance(excluded_providers, list):
+                return jsonify({"error": "'excluded_providers' must be a list of strings"}), 400
+            excluded_providers = [str(p) for p in excluded_providers]
+        else:
+            excluded_providers = []
+
     except (ValueError, TypeError, KeyError):
         return jsonify({"error": "Invalid data in 'savings_goals' or 'earnings' or 'isa_allowance_used' or 'other_savings_income'"}), 400
 
@@ -65,7 +73,8 @@ def optimize():
         savings_goals=savings_goals,
         earnings=earnings,
         isa_allowance_used=isa_allowance_used,
-        other_savings_income=other_savings_income
+        other_savings_income=other_savings_income,
+        excluded_providers=excluded_providers
     )
 
     # 3. Run optimization

--- a/app/services/optimization_service.py
+++ b/app/services/optimization_service.py
@@ -77,7 +77,14 @@ def optimize_savings(input_data: OptimizationInput, accounts: List[Account]) -> 
     total_tax_free_allowance_remaining = max(0, total_tax_free_allowance - other_savings_income)
     isa_allowance_remaining = 20000.0 - (input_data.isa_allowance_used or 0.0)
 
-    # 2. Remove any accounts with term greater than the maximum savings goal
+    # 2. Remove any accounts from excluded providers
+    excluded_providers = input_data.excluded_providers or []
+    if excluded_providers:
+        excluded_lower = {p.lower() for p in excluded_providers}
+        accounts = [acc for acc in accounts if acc.platform.lower() not in excluded_lower]
+        print(f"After excluding providers {excluded_providers}: {len(accounts)} accounts remaining.")
+
+    # 3. Remove any accounts with term greater than the maximum savings goal
     max_horizon = max(g.horizon for g in input_data.savings_goals)
     eligible_accounts = [
         acc for acc in accounts


### PR DESCRIPTION
- Introduced `excluded_providers` field in `OptimizationInput` model to allow users to specify providers to exclude from optimization.
- Updated `optimize` route to validate and handle the `excluded_providers` input.
- Modified the optimization service to filter out accounts from excluded providers, enhancing the customization of the optimization process.